### PR TITLE
Version 1.1.0

### DIFF
--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",
@@ -71,6 +71,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "ReleaseFolder": {
+          "type": "string"
         },
         "ReleaseNameVersion": {
           "type": "boolean"

--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ricaun.Nuke.PackageBuilder" Version="*" />
+    <PackageReference Include="ricaun.Nuke" Version="*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] / 2023-10-02
+### Features
+- Package for version `net5.0+`
+### Updated
+- Force `DownloadBundleAsync` to create `Directory` if not exist.
+- Update `ReferenceLoaderUtils` for NET and NETFRAMEWORK
+### Removed
+- Remove methods with `Obsolete` attribute
+### Tests
+- Update `ReferenceLoaderUtils_Tests` for NET and NETFRAMEWORK
+- Update `RevitInstallationUtils_Tests` count to chech string.Copy obsolete
+
 ## [1.0.3] / 2023-03-16
 ### Fixed
 - Fix `Costura` problem with `RevitInstallationUtils.CreateInstanceAndUnwrap`.
@@ -32,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ricaun.Revit.Installation.Tests`
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.1.0]: ../../compare/1.0.3...1.1.0
 [1.0.3]: ../../compare/1.0.2...1.0.3
 [1.0.2]: ../../compare/1.0.1...1.0.2
 [1.0.1]: ../../compare/1.0.0...1.0.1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build](../../actions/workflows/Build.yml/badge.svg)](../../actions)
 [![.NET Framework 4.5](https://img.shields.io/badge/.NET%20Framework%204.5-blue.svg)](../..)
 [![.NET Standard 2.0](https://img.shields.io/badge/-.NET%20Standard%202.0-blue)](../..)
+[![.NET 5.0](https://img.shields.io/badge/-.NET%205.0-blue)](../..)
 
 ## Features
 ### ApplicationPluginsUtils

--- a/ricaun.Revit.Installation.Tests/ReferenceLoaderUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/ReferenceLoaderUtils_Tests.cs
@@ -32,5 +32,20 @@ namespace ricaun.Revit.Installation.Tests
             }
             Assert.Zero(AppDomain.CurrentDomain.ReflectionOnlyGetAssemblies().Length);
         }
+
+        [Test]
+        public void ReferenceLoaderUtils_Tests_GetReferencesRepeat_Assemblies()
+        {
+            var assemblyFile = Assembly.GetExecutingAssembly().Location;
+            var startWith = AppDomain.CurrentDomain.GetAssemblies().Length;
+            for (int i = 0; i < 5; i++)
+            {
+                var names = ReferenceLoaderUtils.GetReferencedAssemblies(assemblyFile);
+                Assert.IsNotNull(names.FirstOrDefault(e => e.Name.StartsWith("nunit.framework")));
+                Assert.IsNotNull(names.FirstOrDefault(e => e.Name.StartsWith("ricaun.Revit.Installation")));
+            }
+            var endWith = AppDomain.CurrentDomain.GetAssemblies().Length;
+            Assert.Zero(endWith - startWith);
+        }
     }
 }

--- a/ricaun.Revit.Installation.Tests/RevitInstallationUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/RevitInstallationUtils_Tests.cs
@@ -10,6 +10,17 @@ namespace ricaun.Revit.Installation.Tests
     public class RevitInstallationUtils_Tests
     {
         [Test]
+        public void InstalledRevit_Test_Count()
+        {
+            foreach (var installedRevit in RevitInstallationUtils.InstalledRevit)
+            {
+                var count = RevitInstallationUtils.InstalledRevit.Count(e => e.Version == installedRevit.Version);
+                Console.WriteLine($"{installedRevit} : {count}");
+                Assert.That(count, Is.EqualTo(1));
+            }
+        }
+
+        [Test]
         public void InstalledRevit_Test_Show()
         {
             foreach (var installedRevit in RevitInstallationUtils.InstalledRevit)

--- a/ricaun.Revit.Installation.Tests/ricaun.Revit.Installation.Tests.csproj
+++ b/ricaun.Revit.Installation.Tests/ricaun.Revit.Installation.Tests.csproj
@@ -1,17 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net45;net5.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
+++ b/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
@@ -61,20 +61,6 @@ namespace ricaun.Revit.Installation
         }
         #endregion
 
-        #region Extract
-        /// <summary>
-        /// ExtractBundle from a local path
-        /// </summary>
-        /// <param name="applicationPluginsFolder"></param>
-        /// <param name="bundleZipPath"></param>
-        [Obsolete("Use DownloadBundle insted.")]
-        public static void ExtractBundle(string applicationPluginsFolder, string bundleZipPath)
-        {
-            ExtractBundleZipToDirectory(bundleZipPath, applicationPluginsFolder);
-            if (File.Exists(bundleZipPath)) File.Delete(bundleZipPath);
-        }
-        #endregion
-
         #region Download
         /// <summary>
         /// Download and unzip Bundle
@@ -101,6 +87,9 @@ namespace ricaun.Revit.Installation
         /// <returns></returns>
         public static async Task<bool> DownloadBundleAsync(string applicationPluginsFolder, string address, Action<Exception> downloadFileException = null)
         {
+            if (!Directory.Exists(applicationPluginsFolder))
+                Directory.CreateDirectory(applicationPluginsFolder);
+
             var fileName = Path.GetFileName(address);
             var zipPath = Path.Combine(applicationPluginsFolder, fileName);
             var result = false;

--- a/ricaun.Revit.Installation/ReferenceLoaderUtils.NET.cs
+++ b/ricaun.Revit.Installation/ReferenceLoaderUtils.NET.cs
@@ -1,0 +1,101 @@
+﻿namespace ricaun.Revit.Installation
+{
+#if NET
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+    using System.Runtime.Loader;
+
+    /// <summary>
+    /// ReferenceLoaderUtils
+    /// </summary>
+    internal static partial class ReferenceLoaderUtils
+    {
+        /// <summary>
+        /// GetReferencedAssemblies by Load Assembly with <see cref="ReferenceLoaderUtils.SimpleLoadContextUtil"/>
+        /// </summary>
+        /// <param name="assemblyPath"></param>
+        /// <returns></returns>
+        public static AssemblyName[] GetReferencedAssemblies(string assemblyPath)
+        {
+            var result = new AssemblyName[] { };
+            SimpleLoadContextUtil.LoadAndUnload(assemblyPath, (assembly) =>
+            {
+                result = assembly.GetReferencedAssemblies().ToArray();
+            });
+
+            return result;
+        }
+
+        /// <summary>
+        /// SimpleLoadContextUtil
+        /// </summary>
+        public class SimpleLoadContextUtil
+        {
+            private const int RepeatGC = 10;
+
+            /// <summary>
+            /// LoadContextWeakReference
+            /// </summary>
+            internal static WeakReference LoadContextWeakReference;
+
+            /// <summary>
+            /// Load and unload assembly
+            /// </summary>
+            /// <param name="assemblyPath"></param>
+            /// <param name="assemblyPluginAction"></param>
+            /// <returns>WeekReference IsAlive</returns>
+            public static bool LoadAndUnload(string assemblyPath, Action<Assembly> assemblyPluginAction = null)
+            {
+                ExecuteAndUnload(assemblyPath, out LoadContextWeakReference, assemblyPluginAction);
+
+                for (int i = 0; LoadContextWeakReference.IsAlive && (i < RepeatGC); i++)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                }
+
+                return LoadContextWeakReference.IsAlive;
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            internal static void ExecuteAndUnload(string assemblyPath, out WeakReference alcWeakRef, Action<Assembly> assemblyPluginAction = null)
+            {
+                var alc = new SimpleLoadContext(assemblyPath);
+                Assembly assemblyPlugin = alc.LoadFromAssemblyPath(assemblyPath);
+
+                assemblyPluginAction?.Invoke(assemblyPlugin);
+
+                alcWeakRef = new WeakReference(alc, trackResurrection: true);
+                alc.Unload();
+            }
+        }
+
+        /// <summary>
+        /// SimpleLoadContext
+        /// </summary>
+        /// <remarks>https://learn.microsoft.com/en-us/dotnet/standard/assembly/unloadability</remarks>
+        internal class SimpleLoadContext : AssemblyLoadContext
+        {
+            private AssemblyDependencyResolver _resolver;
+
+            public SimpleLoadContext(string mainAssemblyToLoadPath) : base(isCollectible: true)
+            {
+                _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath);
+            }
+
+            protected override Assembly Load(AssemblyName name)
+            {
+                string assemblyPath = _resolver.ResolveAssemblyToPath(name);
+                if (assemblyPath != null)
+                {
+                    return LoadFromAssemblyPath(assemblyPath);
+                }
+
+                return null;
+            }
+        }
+    }
+#endif
+}

--- a/ricaun.Revit.Installation/ReferenceLoaderUtils.NETFRAMEWORK.cs
+++ b/ricaun.Revit.Installation/ReferenceLoaderUtils.NETFRAMEWORK.cs
@@ -1,0 +1,92 @@
+﻿namespace ricaun.Revit.Installation
+{
+#if NETFRAMEWORK
+    using System;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    /// <summary>
+    /// ReferenceLoaderUtils
+    /// </summary>
+    internal static partial class ReferenceLoaderUtils
+    {
+        /// <summary>
+        /// Get references of the <paramref name="assemblyPath"/> using a diferent AppDomain
+        /// </summary>
+        /// <param name="assemblyPath"></param>
+        /// <returns></returns>
+        public static AssemblyName[] GetReferencedAssemblies(string assemblyPath)
+        {
+            var settings = new AppDomainSetup
+            {
+                ApplicationBase = AppDomain.CurrentDomain.BaseDirectory,
+            };
+            var childDomain = AppDomain.CreateDomain(Guid.NewGuid().ToString(), null, settings);
+
+            var loader = childDomain.CreateReferenceLoader();
+
+            //This operation is executed in the new AppDomain
+            var assemblyNames = loader.LoadReferences(assemblyPath);
+
+            AppDomain.Unload(childDomain);
+
+            return assemblyNames;
+        }
+
+        private static ReferenceLoader CreateReferenceLoader(this AppDomain domain)
+        {
+            return domain.CreateInstanceAndUnwrap<ReferenceLoader>();
+        }
+
+        private static T CreateInstanceAndUnwrap<T>(this AppDomain domain, params object[] args) where T : MarshalByRefObject
+        {
+            try
+            {
+                var handle = Activator.CreateInstance(domain,
+                           typeof(T).Assembly.FullName,
+                           typeof(T).FullName,
+                           false, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, args, CultureInfo.CurrentCulture, new object[0]);
+
+                return (T)handle.Unwrap();
+            }
+            catch { }
+
+            try
+            {
+                var handle = domain.CreateInstanceFrom(
+                        typeof(T).Assembly.Location,
+                        typeof(T).FullName,
+                        false, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, args, CultureInfo.CurrentCulture, new object[0]);
+
+                return (T)handle.Unwrap();
+            }
+            catch (Exception ex)
+            {
+                throw new FileNotFoundException($"CreateInstanceFromAndUnwrap fail to CreateInstance<{typeof(T).Name}>, Location: {typeof(T).Assembly.Location}", ex);
+            }
+        }
+
+        /// <summary>
+        /// ReferenceLoader
+        /// <code>
+        /// https://stackoverflow.com/questions/225330/how-to-load-a-net-assembly-for-reflection-operations-and-subsequently-unload-it/37970043#37970043
+        /// </code>
+        /// </summary>
+        private class ReferenceLoader : MarshalByRefObject
+        {
+            /// <summary>
+            /// LoadReferences
+            /// </summary>
+            /// <param name="assemblyPath"></param>
+            /// <returns></returns>
+            public AssemblyName[] LoadReferences(string assemblyPath)
+            {
+                var assembly = Assembly.ReflectionOnlyLoadFrom(assemblyPath);
+                var assemblyNames = assembly.GetReferencedAssemblies().ToArray();
+                return assemblyNames;
+            }
+        }
+    }
+#endif
+}

--- a/ricaun.Revit.Installation/ReferenceLoaderUtils.cs
+++ b/ricaun.Revit.Installation/ReferenceLoaderUtils.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Reflection;
 
 namespace ricaun.Revit.Installation
@@ -9,85 +6,10 @@ namespace ricaun.Revit.Installation
     /// <summary>
     /// ReferenceLoaderUtils
     /// </summary>
-    public static class ReferenceLoaderUtils
+    internal static partial class ReferenceLoaderUtils
     {
 #if NETFRAMEWORK
-        /// <summary>
-        /// Get references of the <paramref name="assemblyPath"/> using a diferent AppDomain
-        /// </summary>
-        /// <param name="assemblyPath"></param>
-        /// <returns></returns>
-        public static AssemblyName[] GetReferencedAssemblies(string assemblyPath)
-        {
-            var settings = new AppDomainSetup
-            {
-                ApplicationBase = AppDomain.CurrentDomain.BaseDirectory,
-            };
-            var childDomain = AppDomain.CreateDomain(Guid.NewGuid().ToString(), null, settings);
-
-            var loader = childDomain.CreateReferenceLoader();
-
-            //This operation is executed in the new AppDomain
-            var assemblyNames = loader.LoadReferences(assemblyPath);
-
-            AppDomain.Unload(childDomain);
-
-            return assemblyNames;
-        }
-
-        private static ReferenceLoader CreateReferenceLoader(this AppDomain domain)
-        {
-            return domain.CreateInstanceAndUnwrap<ReferenceLoader>();
-        }
-
-        private static T CreateInstanceAndUnwrap<T>(this AppDomain domain, params object[] args) where T : MarshalByRefObject
-        {
-            try
-            {
-                var handle = Activator.CreateInstance(domain,
-                           typeof(T).Assembly.FullName,
-                           typeof(T).FullName,
-                           false, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, args, CultureInfo.CurrentCulture, new object[0]);
-
-                return (T)handle.Unwrap();
-            }
-            catch { }
-
-            try
-            {
-                var handle = domain.CreateInstanceFrom(
-                        typeof(T).Assembly.Location,
-                        typeof(T).FullName,
-                        false, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, args, CultureInfo.CurrentCulture, new object[0]);
-
-                return (T)handle.Unwrap();
-            }
-            catch (Exception ex)
-            {
-                throw new FileNotFoundException($"CreateInstanceFromAndUnwrap fail to CreateInstance<{typeof(T).Name}>, Location: {typeof(T).Assembly.Location}", ex);
-            }
-        }
-
-        /// <summary>
-        /// ReferenceLoader
-        /// <code>
-        /// https://stackoverflow.com/questions/225330/how-to-load-a-net-assembly-for-reflection-operations-and-subsequently-unload-it/37970043#37970043
-        /// </code>
-        /// </summary>
-        public class ReferenceLoader : MarshalByRefObject
-        {
-            /// <summary>
-            /// LoadReferences
-            /// </summary>
-            /// <param name="assemblyPath"></param>
-            /// <returns></returns>
-            public AssemblyName[] LoadReferences(string assemblyPath)
-            {
-                var assembly = Assembly.ReflectionOnlyLoadFrom(assemblyPath);
-                var assemblyNames = assembly.GetReferencedAssemblies().ToArray();
-                return assemblyNames;
-            }
-        }
+#elif NET
 #else
         /// <summary>
         /// GetReferencedAssemblies by Load Assembly with <see cref="File.ReadAllBytes"/>
@@ -96,9 +18,18 @@ namespace ricaun.Revit.Installation
         /// <returns></returns>
         public static AssemblyName[] GetReferencedAssemblies(string assemblyPath)
         {
+            return GetReferencedAssembliesDefault(assemblyPath);
+        }
+#endif
+        /// <summary>
+        /// GetReferencedAssemblies by Load Assembly with <see cref="File.ReadAllBytes"/>
+        /// </summary>
+        /// <param name="assemblyPath"></param>
+        /// <returns></returns>
+        internal static AssemblyName[] GetReferencedAssembliesDefault(string assemblyPath)
+        {
             var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
             return assembly.GetReferencedAssemblies();
         }
-#endif
     }
 }

--- a/ricaun.Revit.Installation/RevitInstallationUtils.cs
+++ b/ricaun.Revit.Installation/RevitInstallationUtils.cs
@@ -48,7 +48,9 @@ namespace ricaun.Revit.Installation
             uint iProductIndex;
             do
             {
-                productCodes.Add(string.Copy(code));
+                // string.Copy this is obsolete
+                // productCodes.Add(string.Copy(code));
+                productCodes.Add(new string(code.ToCharArray()));
                 iProductIndex = num;
                 num++;
             }

--- a/ricaun.Revit.Installation/ricaun.Revit.Installation.csproj
+++ b/ricaun.Revit.Installation/ricaun.Revit.Installation.csproj
@@ -2,7 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
@@ -16,7 +17,7 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants></DefineConstants>
-    <NoWarn>MSB3052</NoWarn>
+    <NoWarn>$(NoWarn);MSB3052</NoWarn>
     <DebugType>None</DebugType>
   </PropertyGroup>
 
@@ -30,7 +31,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Revit.Installation</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.1.0</Version>
     <ProjectGuid>{A6D57EEA-04DE-4F12-951E-481C6861C9F8}</ProjectGuid>
   </PropertyGroup>
 
@@ -64,6 +65,7 @@
     <RepositoryUrl>https://github.com/$(GitHubRepositoryOwner)/$(PackageId)</RepositoryUrl>
     <RepositoryType>github</RepositoryType>
     <PackageIcon>icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIconUrl />
   </PropertyGroup>
 


### PR DESCRIPTION
### Features
- Package for version `net5.0+` 
### Updated
- Force `DownloadBundleAsync` to create `Directory` if not exist.
- Update `ReferenceLoaderUtils` for NET and NETFRAMEWORK 
### Removed
- Remove methods with `Obsolete` attribute 
### Tests
- Update `ReferenceLoaderUtils_Tests` for NET and NETFRAMEWORK
- Update `RevitInstallationUtils_Tests` count to chech string.Copy obsolete