### PR TITLE
Version 1.3.2

### DIFF
--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -33,7 +33,7 @@
         "PrePack",
         "Release",
         "Sign",
-        "TestLocal"
+        "Test"
       ]
     },
     "Verbosity": {
@@ -152,13 +152,13 @@
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"
         },
-        "TestLocalBuildStopWhenFailed": {
+        "TestBuildStopWhenFailed": {
           "type": "boolean"
         },
-        "TestLocalProjectName": {
+        "TestProjectName": {
           "type": "string"
         },
-        "TestLocalResults": {
+        "TestResults": {
           "type": "boolean"
         },
         "UnlistNuGet": {

--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -107,6 +107,9 @@
   "allOf": [
     {
       "properties": {
+        "EnableForkedRepository": {
+          "type": "boolean"
+        },
         "Folder": {
           "type": "string"
         },
@@ -117,11 +120,11 @@
         "MainName": {
           "type": "string"
         },
-        "NugetApiKey": {
+        "NuGetApiKey": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
-        "NugetApiUrl": {
+        "NuGetApiUrl": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
@@ -158,7 +161,7 @@
         "TestLocalResults": {
           "type": "boolean"
         },
-        "UnlistNuget": {
+        "UnlistNuGet": {
           "type": "boolean"
         }
       }

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -3,7 +3,7 @@ using Nuke.Common.Execution;
 using ricaun.Nuke;
 using ricaun.Nuke.Components;
 
-class Build : NukeBuild, IPublishPack, ITestLocal, IPrePack
+class Build : NukeBuild, IPublishPack, ITest, IPrePack
 {
     public static int Main() => Execute<Build>(x => x.From<IPublishPack>().Build);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `FinalPathNameExtension` to fix localized `InstallLocation`. (Fix: #13)
 - Update `GetProcesses` to use `FinalPathNameExtension` to fix localized `InstallLocation`.
 - Update typo related to `Journal`.
+- Update `ApplicationPluginsUtils` to fix `bundle.zip` download.
 ### Tests
 - Add `FinalPathName_Tests` with `english`, `portuguese` and `german` tests.
+- Add `BundleCreatorUtils` to test `ApplicationPluginsUtils` with fake `bundle.zip`.
 
 ## [1.3.1] / 2024-12-16
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.2] / 2025-03-05
 ### Features
+- Support localized `InstallLocation` path.
 ### Updates
 - Add `FinalPathNameExtension` to fix localized `InstallLocation`. (Fix: #13)
 - Update `GetProcesses` to use `FinalPathNameExtension` to fix localized `InstallLocation`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Features
 ### Updates
 - Add `FinalPathNameExtension` to fix localized `InstallLocation`. (Fix: #13)
+- Update typo related to `Journal`.
 ### Tests
 - Add `FinalPathName_Tests` with `english`, `portuguese` and `german` tests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Features
 ### Updates
 - Add `FinalPathNameExtension` to fix localized `InstallLocation`. (Fix: #13)
+- Update `GetProcesses` to use `FinalPathNameExtension` to fix localized `InstallLocation`.
 - Update typo related to `Journal`.
 ### Tests
 - Add `FinalPathName_Tests` with `english`, `portuguese` and `german` tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] / 2025-03-05
+### Features
+### Updates
+- Add `FinalPathNameExtension` to fix localized `InstallLocation`. (Fix: #13)
+### Tests
+- Add `FinalPathName_Tests` with `english`, `portuguese` and `german` tests.
+
 ## [1.3.1] / 2024-12-16
 ### Features
 - `ApplicationPluginsUtils` with `Mutex` to prevent multiple instances. (Fix: #11)
@@ -82,6 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ricaun.Revit.Installation.Tests`
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.3.2]: ../../compare/1.3.1...1.3.2
 [1.3.1]: ../../compare/1.3.0...1.3.1
 [1.3.0]: ../../compare/1.2.0...1.3.0
 [1.2.0]: ../../compare/1.1.2...1.2.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.3.2-beta</Version>
+    <Version>1.3.2</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+    <Version>1.3.2-alpha.1</Version>
+	</PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.3.2-alpha.1</Version>
+    <Version>1.3.2-beta</Version>
 	</PropertyGroup>
 </Project>

--- a/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
@@ -15,7 +15,7 @@ namespace ricaun.Revit.Installation.Tests
         {
             var bundleUrl = $@"https://github.com/ricaun-io/{projectName}/releases/latest/download/{projectName}.bundle.zip";
 
-            var applicationPluginsFolder = RevitUtils.GetCurrentUserApplicationPluginsFolder();
+            var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
             var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
 
             Console.WriteLine($"DownloadBundle: {bundleName}");
@@ -45,7 +45,7 @@ namespace ricaun.Revit.Installation.Tests
         {
             var bundleUrl = $@"https://github.com/ricaun-io/{projectName}/releases/latest/download/{projectName}.bundle.zip";
 
-            var applicationPluginsFolder = RevitUtils.GetCurrentUserApplicationPluginsFolder();
+            var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
             var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
 
             Console.WriteLine($"DownloadBundle: {bundleName}");
@@ -76,7 +76,7 @@ namespace ricaun.Revit.Installation.Tests
         {
             var bundleUrl = BundleCreatorUtils.CreateBundleZip(projectName, includeBundleDirectory, includeContents);
 
-            var applicationPluginsFolder = RevitUtils.GetCurrentUserApplicationPluginsFolder();
+            var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
             var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
 
             Console.WriteLine($"DownloadBundle: {bundleName}");

--- a/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using ricaun.Revit.Installation.Tests.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,10 +10,9 @@ namespace ricaun.Revit.Installation.Tests
 {
     public class ApplicationPluginsUtils_Tests
     {
-        [Test]
-        public async Task ApplicationPluginsUtils_Test_Download_Async()
+        [TestCase("RevitAddin.DA.Tester")]
+        public async Task ApplicationPluginsUtils_Test_Download_Async(string projectName)
         {
-            var projectName = "RevitAddin.DA.Tester";
             var bundleUrl = $@"https://github.com/ricaun-io/{projectName}/releases/latest/download/{projectName}.bundle.zip";
 
             var applicationPluginsFolder = RevitUtils.GetCurrentUserApplicationPluginsFolder();
@@ -30,7 +30,8 @@ namespace ricaun.Revit.Installation.Tests
                     {
                         Console.WriteLine(e);
                         Assert.Fail(e.Message);
-                    }, (log) => {
+                    }, (log) =>
+                    {
                         //Console.WriteLine(log);
                     });
                 });
@@ -39,10 +40,9 @@ namespace ricaun.Revit.Installation.Tests
             await Task.WhenAll(tasks);
         }
 
-            [Test]
-        public void ApplicationPluginsUtils_Test_Download()
+        [TestCase("RevitAddin.DA.Tester")]
+        public void ApplicationPluginsUtils_Test_Download(string projectName)
         {
-            var projectName = "RevitAddin.DA.Tester";
             var bundleUrl = $@"https://github.com/ricaun-io/{projectName}/releases/latest/download/{projectName}.bundle.zip";
 
             var applicationPluginsFolder = RevitUtils.GetCurrentUserApplicationPluginsFolder();
@@ -54,7 +54,39 @@ namespace ricaun.Revit.Installation.Tests
             {
                 Console.WriteLine(e);
                 Assert.Fail(e.Message);
-            }, (log) => {
+            }, (log) =>
+            {
+                Console.WriteLine(log);
+            });
+
+            Console.WriteLine($"Bundle Exists: {Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName))}");
+            Assert.IsTrue(Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName)));
+
+            Thread.Sleep(1000);
+
+            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName);
+            Console.WriteLine($"Bundle Exists: {Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName))}");
+        }
+
+        [TestCase("FakeBundle", false)]
+        [TestCase("FakeBundle", true)]
+        [TestCase("FakeBundle", false, false)]
+        [TestCase("FakeBundle", true, false)]
+        public void ApplicationPluginsUtils_Test_BundleCreatorUtils(string projectName, bool includeBundleDirectory, bool includeContents = true)
+        {
+            var bundleUrl = BundleCreatorUtils.CreateBundleZip(projectName, includeBundleDirectory, includeContents);
+
+            var applicationPluginsFolder = RevitUtils.GetCurrentUserApplicationPluginsFolder();
+            var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
+
+            Console.WriteLine($"DownloadBundle: {bundleName}");
+
+            ApplicationPluginsUtils.DownloadBundle(applicationPluginsFolder, bundleUrl, (e) =>
+            {
+                Console.WriteLine(e);
+                Assert.Fail(e.Message);
+            }, (log) =>
+            {
                 Console.WriteLine(log);
             });
 

--- a/ricaun.Revit.Installation.Tests/FinalPathName_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/FinalPathName_Tests.cs
@@ -10,7 +10,7 @@ namespace ricaun.Revit.Installation.Tests
         [TestCase("Program Files")] // English
         [TestCase("Arquivos de Programas")] // Portuguese
         [TestCase("Programme")] // German
-        public void GetMainModuleFileName_Test(string programFiles)
+        public void GetFinalPathName_For_ProgramFiles(string programFiles)
         {
             var pathShouldBe = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 

--- a/ricaun.Revit.Installation.Tests/FinalPathName_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/FinalPathName_Tests.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using ricaun.Revit.Installation.Utils;
+using System;
+using System.IO;
+
+namespace ricaun.Revit.Installation.Tests
+{
+    public class FinalPathName_Tests
+    {
+        [TestCase("Program Files")] // English
+        [TestCase("Arquivos de Programas")] // Portuguese
+        [TestCase("Programme")] // German
+        public void GetMainModuleFileName_Test(string programFiles)
+        {
+            var pathShouldBe = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+
+            var directory = Path.GetDirectoryName(pathShouldBe);
+            var path = Path.Combine(directory, programFiles);
+
+            try
+            {
+                var finalPath = FinalPathNameExtension.GetFinalPathName(path);
+                Console.WriteLine(finalPath);
+                Assert.That(finalPath, Is.EqualTo(pathShouldBe));
+            }
+            catch
+            {
+                Assert.Ignore($"'{programFiles}' does not exist in the system.");
+            }
+        }
+    }
+}

--- a/ricaun.Revit.Installation.Tests/RevitInstallationUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/RevitInstallationUtils_Tests.cs
@@ -92,7 +92,7 @@ namespace ricaun.Revit.Installation.Tests
         [Test]
         [Explicit]
         [Ignore("This test will start Revit")]
-        public void InstalledRevit_Test_StartWithJornal()
+        public void InstalledRevit_Test_StartWithJournal()
         {
             var InstalledRevits = RevitInstallationUtils.InstalledRevit;
             var installedRevit = InstalledRevits.LastOrDefault();
@@ -102,9 +102,9 @@ namespace ricaun.Revit.Installation.Tests
                 {
                     string workingDirectory = Path.Combine(Path.GetTempPath(), "_RevitInstallation_Test_");
                     Directory.CreateDirectory(workingDirectory);
-                    Console.WriteLine($"{installedRevit}: StartWithJornal {workingDirectory}");
+                    Console.WriteLine($"{installedRevit}: StartWithJournal {workingDirectory}");
                     var forceToExited = false;
-                    process = installedRevit.StartWithJornal(workingDirectory);
+                    process = installedRevit.StartWithJournal(workingDirectory);
                     process.ErrorDataReceived += (s, e) =>
                     {
                         Console.WriteLine(e.Data);

--- a/ricaun.Revit.Installation.Tests/Utils/BundleCreatorUtils.cs
+++ b/ricaun.Revit.Installation.Tests/Utils/BundleCreatorUtils.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace ricaun.Revit.Installation.Tests.Utils
+{
+    public static class BundleCreatorUtils
+    {
+        public static string CreateBundleZip(string projectName, bool includeBundleDirectory = true, bool includeContents = true)
+        {
+            var bundleFileName = $"{projectName}.bundle";
+            var zipFileName = $"{bundleFileName}.zip";
+            var tempPath = Path.Combine(Path.GetTempPath(), "BundleCreatorUtils");
+
+            if (Directory.Exists(tempPath))
+                Directory.Delete(tempPath, true);
+
+            Directory.CreateDirectory(tempPath);
+
+            var zipFilePath = Path.Combine(tempPath, zipFileName);
+            var sourceBundlePath = Path.Combine(tempPath, bundleFileName);
+            Directory.CreateDirectory(sourceBundlePath);
+
+            var packageContentsFile = Path.Combine(sourceBundlePath, "PackageContents.xml");
+            File.WriteAllText(packageContentsFile, string.Empty);
+
+            if (includeContents)
+            {
+                var contentsFolder = Path.Combine(sourceBundlePath, "Contents");
+                Directory.CreateDirectory(contentsFolder);
+                var contentFile = Path.Combine(contentsFolder, "File.xml");
+                File.WriteAllText(contentFile, string.Empty);
+            }
+
+            ZipFile.CreateFromDirectory(sourceBundlePath, zipFilePath, CompressionLevel.NoCompression, includeBundleDirectory);
+
+            return zipFilePath;
+        }
+    }
+}

--- a/ricaun.Revit.Installation.sln
+++ b/ricaun.Revit.Installation.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{DE578EEA-F3FF-4861-8EAD-0EDB34D5A63E}"
 	ProjectSection(SolutionItems) = preProject
 		CHANGELOG.md = CHANGELOG.md
+		Directory.Build.props = Directory.Build.props
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection

--- a/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
+++ b/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
@@ -134,8 +134,6 @@ namespace ricaun.Revit.Installation
             if (destinationDirectoryName.EndsWith(CONST_BUNDLE) == false)
                 destinationDirectoryName = Path.Combine(destinationDirectoryName, Path.GetFileNameWithoutExtension(archiveFileName));
 
-            Console.WriteLine(destinationDirectoryName);
-
             using (var archive = ZipFile.OpenRead(archiveFileName))
             {
                 string baseDirectory = string.Empty;

--- a/ricaun.Revit.Installation/RevitInstallationExtension.cs
+++ b/ricaun.Revit.Installation/RevitInstallationExtension.cs
@@ -42,24 +42,24 @@ namespace ricaun.Revit.Installation
         }
 
         /// <summary>
-        /// Start RevitInstallation with Jornal in <paramref name="workingDirectory"/>.
+        /// Start RevitInstallation with Journal in <paramref name="workingDirectory"/>.
         /// Any .addin in the <paramref name="workingDirectory"/> gonna be loaded.
         /// </summary>
         /// <param name="revitInstallation"></param>
         /// <param name="workingDirectory"></param>
         /// <param name="arguments"></param>
         /// <returns></returns>
-        public static Process StartWithJornal(this RevitInstallation revitInstallation,
+        public static Process StartWithJournal(this RevitInstallation revitInstallation,
             string workingDirectory,
             string arguments = DefaultArguments)
         {
             var revitExe = Path.Combine(revitInstallation.InstallLocation, ExecuteName);
-            string jornalPath = CreateJornalFile(workingDirectory);
+            string journalPath = CreateJournalFile(workingDirectory);
             ProcessStartInfo processStartInfo = new ProcessStartInfo()
             {
                 FileName = revitExe,
                 WorkingDirectory = workingDirectory,
-                Arguments = jornalPath + " " + arguments,
+                Arguments = journalPath + " " + arguments,
                 UseShellExecute = false
             };
             var process = new Process();
@@ -127,12 +127,12 @@ namespace ricaun.Revit.Installation
             return Process.GetProcessesByName(ProcessName);
         }
 
-        private static string CreateJornalFile(string workingDirectory)
+        private static string CreateJournalFile(string workingDirectory)
         {
-            const string JORNAL_FILE = "journal.txt";
-            string jornalPath = Path.Combine(workingDirectory, JORNAL_FILE);
-            File.WriteAllText(jornalPath, $"'C {DateTime.Now.ToString("dd-MMM-yyyy HH:mm:ss.fff")}; \r\nDim Jrn\r\nSet Jrn = CrsJournalScript");
-            return jornalPath;
+            const string JOURNAL_FILE = "journal.txt";
+            string journalPath = Path.Combine(workingDirectory, JOURNAL_FILE);
+            File.WriteAllText(journalPath, $"'C {DateTime.Now.ToString("dd-MMM-yyyy HH:mm:ss.fff")}; \r\nDim Jrn\r\nSet Jrn = CrsJournalScript");
+            return journalPath;
         }
         #endregion
     }

--- a/ricaun.Revit.Installation/RevitInstallationExtension.cs
+++ b/ricaun.Revit.Installation/RevitInstallationExtension.cs
@@ -88,7 +88,7 @@ namespace ricaun.Revit.Installation
         public static Process[] GetProcesses(this RevitInstallation revitInstallation)
         {
             return GetRevitProcesses()
-                .Where(e => e.GetMainModuleFileName().Contains(revitInstallation.InstallLocation))
+                .Where(e => e.GetMainModuleFileName().Contains(revitInstallation.InstallLocation.TryGetFinalPathName()))
                 .ToArray();
         }
         #endregion

--- a/ricaun.Revit.Installation/Utils/FinalPathNameExtension.cs
+++ b/ricaun.Revit.Installation/Utils/FinalPathNameExtension.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace ricaun.Revit.Installation.Utils
+{
+    internal static class FinalPathNameExtension
+    {
+        private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
+        private const string DLL_NAME = "Kernel32.dll";
+        private const uint FILE_READ_EA = 0x0008;
+        private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x2000000;
+
+        [DllImport(DLL_NAME, SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern uint GetFinalPathNameByHandle(
+            IntPtr hFile,
+            [MarshalAs(UnmanagedType.LPTStr)] StringBuilder lpszFilePath,
+            uint cchFilePath,
+            uint dwFlags);
+
+        [DllImport(DLL_NAME, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport(DLL_NAME, CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern IntPtr CreateFile(
+                [MarshalAs(UnmanagedType.LPTStr)] string filename,
+                [MarshalAs(UnmanagedType.U4)] uint access,
+                [MarshalAs(UnmanagedType.U4)] FileShare share,
+                IntPtr securityAttributes, // optional SECURITY_ATTRIBUTES struct or IntPtr.Zero
+                [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
+                [MarshalAs(UnmanagedType.U4)] uint flagsAndAttributes,
+                IntPtr templateFile);
+
+        public static string GetFinalPathName(string path, bool removeLongPathPrefix = true)
+        {
+            const int bufferSize = 1024;
+
+            var fileHandle = CreateFile(path,
+                FILE_READ_EA,
+                FileShare.ReadWrite | FileShare.Delete,
+                IntPtr.Zero,
+                FileMode.Open,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
+
+            if (fileHandle == INVALID_HANDLE_VALUE)
+                throw new FileNotFoundException("File not found.", path);
+
+            try
+            {
+                var fileStringBuilder = new StringBuilder(bufferSize);
+                var res = GetFinalPathNameByHandle(fileHandle, fileStringBuilder, bufferSize, 0);
+
+                if (res == 0)
+                    throw new FileNotFoundException("FinalPathNameByHandle fail.", path);
+
+                var finalPath = fileStringBuilder.ToString();
+
+                if (removeLongPathPrefix)
+                {
+                    // Remove the \\?\ prefix for the long path
+                    finalPath = finalPath.StartsWith(@"\\?\") ? finalPath.Substring(4) : finalPath;
+                }
+
+                return finalPath;
+            }
+            finally
+            {
+                CloseHandle(fileHandle);
+            }
+        }
+    }
+}

--- a/ricaun.Revit.Installation/Utils/FinalPathNameExtension.cs
+++ b/ricaun.Revit.Installation/Utils/FinalPathNameExtension.cs
@@ -34,6 +34,36 @@ namespace ricaun.Revit.Installation.Utils
                 [MarshalAs(UnmanagedType.U4)] uint flagsAndAttributes,
                 IntPtr templateFile);
 
+
+
+        /// <summary>
+        /// Tries to get the final path name of the specified file.
+        /// </summary>
+        /// <param name="path">The path of the file.</param>
+        /// <param name="removeLongPathPrefix">If set to <c>true</c>, removes the long path prefix (\\?\) from the final path.</param>
+        /// <returns>The final path name of the specified file if successful; otherwise, returns the original path.</returns>
+        /// <remarks>
+        /// This method attempts to retrieve the final path name of the specified file. If an error occurs, it returns the original path.
+        /// </remarks>
+        public static string TryGetFinalPathName(this string path, bool removeLongPathPrefix = true)
+        {
+            try
+            {
+                return GetFinalPathName(path, removeLongPathPrefix);
+            }
+            catch
+            {
+                return path;
+            }
+        }
+
+        /// <summary>
+        /// Gets the final path name of the specified file.
+        /// </summary>
+        /// <param name="path">The path of the file.</param>
+        /// <param name="removeLongPathPrefix">If set to <c>true</c>, removes the long path prefix (\\?\) from the final path.</param>
+        /// <returns>The final path name of the specified file.</returns>
+        /// <exception cref="FileNotFoundException">Thrown when the file is not found or the final path name cannot be retrieved.</exception>
         public static string GetFinalPathName(string path, bool removeLongPathPrefix = true)
         {
             const int bufferSize = 1024;

--- a/ricaun.Revit.Installation/ricaun.Revit.Installation.csproj
+++ b/ricaun.Revit.Installation/ricaun.Revit.Installation.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Revit.Installation</PackageId>
-    <Version>1.3.1</Version>
+    <Version>1.3.2-alpha</Version>
     <ProjectGuid>{A6D57EEA-04DE-4F12-951E-481C6861C9F8}</ProjectGuid>
   </PropertyGroup>
 

--- a/ricaun.Revit.Installation/ricaun.Revit.Installation.csproj
+++ b/ricaun.Revit.Installation/ricaun.Revit.Installation.csproj
@@ -31,8 +31,6 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Revit.Installation</PackageId>
-    <Version>1.3.2-alpha</Version>
-    <ProjectGuid>{A6D57EEA-04DE-4F12-951E-481C6861C9F8}</ProjectGuid>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Features
- Support localized `InstallLocation` path.
### Updates
- Add `FinalPathNameExtension` to fix localized `InstallLocation`. (Fix: #13)
- Update `GetProcesses` to use `FinalPathNameExtension` to fix localized `InstallLocation`.
- Update typo related to `Journal`.
- Update `ApplicationPluginsUtils` to fix `bundle.zip` download.
### Tests
- Add `FinalPathName_Tests` with `english`, `portuguese` and `german` tests.
- Add `BundleCreatorUtils` to test `ApplicationPluginsUtils` with fake `bundle.zip`.
