### PR TITLE
Version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.4.0] / 2025-04-03
 ### Updates
-- Update `RevitInstallation.Start` to start `Process` with `UseShellExecute` true.
+- Update `RevitInstallation.Start` to start `Process` with `UseShellExecute` true. (Fix: #15)
 
 ## [1.3.2] / 2025-03-05
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.4.0] / 2025-04-03
 ### Updates
 - Update `RevitInstallation.Start` to start `Process` with `UseShellExecute` true. (Fix: #15)
+### Tests
+- Test to start Revit to verify if `Process` with `UseShellExecute` works.
 
 ## [1.3.2] / 2025-03-05
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] / 2025-04-03
+### Updates
+- Update `RevitInstallation.Start` to start `Process` with `UseShellExecute` true.
+
 ## [1.3.2] / 2025-03-05
 ### Features
 - Support localized `InstallLocation` path.
@@ -94,6 +98,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ricaun.Revit.Installation.Tests`
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.4.0]: ../../compare/1.3.2...1.4.0
 [1.3.2]: ../../compare/1.3.1...1.3.2
 [1.3.1]: ../../compare/1.3.0...1.3.1
 [1.3.0]: ../../compare/1.2.0...1.3.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.4.0-alpha</Version>
+    <Version>1.4.0-beta</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.4.0-beta</Version>
+    <Version>1.4.0</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.3.2</Version>
+    <Version>1.4.0-alpha</Version>
 	</PropertyGroup>
 </Project>

--- a/ricaun.Revit.Installation.Tests/RevitInstallationUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/RevitInstallationUtils_Tests.cs
@@ -47,6 +47,17 @@ namespace ricaun.Revit.Installation.Tests
         }
 
         [Test]
+        public void InstalledRevit_Start_LastVersion()
+        {
+            var InstalledRevits = RevitInstallationUtils.InstalledRevit;
+            var installedRevit = InstalledRevits.LastOrDefault();
+            if (installedRevit is not null)
+            {
+                installedRevit.Start();
+            }
+        }
+
+        [Test]
         [Explicit]
         [Ignore("This test will start Revit")]
         public void InstalledRevit_Test_Start()

--- a/ricaun.Revit.Installation/RevitInstallationExtension.cs
+++ b/ricaun.Revit.Installation/RevitInstallationExtension.cs
@@ -37,7 +37,14 @@ namespace ricaun.Revit.Installation
         public static Process Start(this RevitInstallation revitInstallation, string arguments = DefaultArguments)
         {
             var revitExe = Path.Combine(revitInstallation.InstallLocation, ExecuteName);
-            var process = Process.Start(revitExe, arguments);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = revitExe,
+                Arguments = arguments,
+                UseShellExecute = true, // This ensures the process is not a child process
+            };
+            var process = Process.Start(startInfo);
+
             return process;
         }
 


### PR DESCRIPTION
### Updates
- Update `RevitInstallation.Start` to start `Process` with `UseShellExecute` true. (Fix: #15)
### Tests
- Test to start Revit to verify if `Process` with `UseShellExecute` works.