### PR TITLE
Version 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] / 2026-02-11
+### Updates
+- Change how `DeleteBundle` deletes the bundle folder, try to delete each folder inside and delete `PackageContents.xml`.
+### Tests
+- Update `ApplicationPluginsUtils_Tests` to check if the bundle folder is deleted.
+
 ## [1.5.0] / 2026-02-10
 ### Updates
 - Obsolete `AllUsers` folder methods because of Revit 2027 changes. (Fix: #17)
@@ -104,6 +110,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ricaun.Revit.Installation.Tests`
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.5.1]: ../../compare/1.5.0...1.5.1
 [1.5.0]: ../../compare/1.4.0...1.5.0
 [1.4.0]: ../../compare/1.3.2...1.4.0
 [1.3.2]: ../../compare/1.3.1...1.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.5.1] / 2026-02-11
 ### Updates
-- Change how `DeleteBundle` deletes the bundle folder, try to delete each folder inside and delete `PackageContents.xml`.
+- Change how `DeleteBundle` deletes the bundle folder, try to move/delete each folder inside and delete `PackageContents.xml`.
 ### Tests
 - Update `ApplicationPluginsUtils_Tests` to check if the bundle folder is deleted.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.5.1] / 2026-02-11
 ### Updates
 - Change how `DeleteBundle` deletes the bundle folder, try to move/delete each folder inside and delete `PackageContents.xml`.
+- Update `DeleteDirectories` to check if folder contains any file been used by any process, if so the deletion will be skipped.
 ### Tests
 - Update `ApplicationPluginsUtils_Tests` to check if the bundle folder is deleted.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.5.1-alpha</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.5.1-rc.3</Version>
+    <Version>1.5.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.5.1-rc.2</Version>
+    <Version>1.5.1-rc.3</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.5.1-rc</Version>
+    <Version>1.5.1-rc.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.5.1-rc.1</Version>
+    <Version>1.5.1-rc.2</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.5.1-alpha</Version>
+    <Version>1.5.1-rc</Version>
 	</PropertyGroup>
 </Project>

--- a/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
@@ -17,20 +17,21 @@ namespace ricaun.Revit.Installation.Tests
         public void Setup()
         {
             // Create a temporary folder for the tests
-            var tempFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
-            if (Directory.Exists(tempFolder))
+            applicationPluginsFolder = Path.Combine(Path.GetTempPath(), $"ApplicationPlugins_{Guid.NewGuid().ToString("N")}");
+            if (Directory.Exists(applicationPluginsFolder))
             {
-                Directory.Delete(tempFolder, true);
+                Directory.Delete(applicationPluginsFolder, true);
             }
-            Directory.CreateDirectory(tempFolder);
+            Directory.CreateDirectory(applicationPluginsFolder);
         }
+
+        private string applicationPluginsFolder;
 
         [TestCase("RevitAddin.DA.Tester")]
         public async Task ApplicationPluginsUtils_Test_Download_Async(string projectName)
         {
             var bundleUrl = $@"https://github.com/ricaun-io/{projectName}/releases/latest/download/{projectName}.bundle.zip";
 
-            var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
             var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
 
             Console.WriteLine($"DownloadBundle: {bundleName}");
@@ -60,7 +61,6 @@ namespace ricaun.Revit.Installation.Tests
         {
             var bundleUrl = $@"https://github.com/ricaun-io/{projectName}/releases/latest/download/{projectName}.bundle.zip";
 
-            var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
             var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
 
             Console.WriteLine($"DownloadBundle: {bundleName}");
@@ -92,7 +92,6 @@ namespace ricaun.Revit.Installation.Tests
             projectName += Guid.NewGuid().ToString("N");
             var bundleUrl = BundleCreatorUtils.CreateBundleZip(projectName, includeBundleDirectory, includeContents);
 
-            var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
             var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
 
             Console.WriteLine($"DownloadBundle: {bundleName}");
@@ -129,7 +128,6 @@ namespace ricaun.Revit.Installation.Tests
             projectName += Guid.NewGuid().ToString("N");
             var bundleUrl = BundleCreatorUtils.CreateBundleZip(projectName);
 
-            var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
             var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
 
             Console.WriteLine($"DownloadBundle: {bundleName}");

--- a/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
@@ -1,8 +1,10 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using ricaun.Revit.Installation.Tests.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +12,18 @@ namespace ricaun.Revit.Installation.Tests
 {
     public class ApplicationPluginsUtils_Tests
     {
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            // Create a temporary folder for the tests
+            var tempFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
+            if (Directory.Exists(tempFolder))
+            {
+                Directory.Delete(tempFolder, true);
+            }
+            Directory.CreateDirectory(tempFolder);
+        }
+
         [TestCase("RevitAddin.DA.Tester")]
         public async Task ApplicationPluginsUtils_Test_Download_Async(string projectName)
         {
@@ -74,6 +88,7 @@ namespace ricaun.Revit.Installation.Tests
         [TestCase("FakeBundle", true, false)]
         public void ApplicationPluginsUtils_Test_BundleCreatorUtils(string projectName, bool includeBundleDirectory, bool includeContents = true)
         {
+            projectName += Guid.NewGuid().ToString("N");
             var bundleUrl = BundleCreatorUtils.CreateBundleZip(projectName, includeBundleDirectory, includeContents);
 
             var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
@@ -90,13 +105,70 @@ namespace ricaun.Revit.Installation.Tests
                 Console.WriteLine(log);
             });
 
-            Console.WriteLine($"Bundle Exists: {Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName))}");
-            Assert.IsTrue(Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName)));
+            var bundleDirectory = Path.Combine(applicationPluginsFolder, bundleName);
+            var bundlePackageContentsPath = Path.Combine(bundleDirectory, "PackageContents.xml");
+
+            Console.WriteLine($"Bundle Exists: {Directory.Exists(bundleDirectory)}");
+            Assert.IsTrue(Directory.Exists(bundleDirectory));
+            Assert.IsTrue(File.Exists(bundlePackageContentsPath));
 
             Thread.Sleep(1000);
 
             ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName);
-            Console.WriteLine($"Bundle Exists: {Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName))}");
+            Console.WriteLine($"Bundle Exists: {Directory.Exists(bundleDirectory)}");
+
+            Assert.IsFalse(Directory.Exists(bundleDirectory));
+        }
+
+        [TestCase("FakeBundleUsedByProcess")]
+        public void ApplicationPluginsUtils_Test_BundleCreatorUtils_FileUsedByProcess(string projectName)
+        {
+            projectName += Guid.NewGuid().ToString("N");
+            var bundleUrl = BundleCreatorUtils.CreateBundleZip(projectName);
+
+            var applicationPluginsFolder = Path.Combine(Path.GetTempPath(), "ApplicationPlugins");
+            var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
+
+            Console.WriteLine($"DownloadBundle: {bundleName}");
+
+            ApplicationPluginsUtils.DownloadBundle(applicationPluginsFolder, bundleUrl, (e) =>
+            {
+                Console.WriteLine(e);
+                Assert.Fail(e.Message);
+            }, (log) =>
+            {
+                Console.WriteLine(log);
+            });
+
+            var bundleDirectory = Path.Combine(applicationPluginsFolder, bundleName);
+            var bundlePackageContentsPath = Path.Combine(bundleDirectory, "PackageContents.xml");
+
+            Console.WriteLine($"Bundle Exists: {Directory.Exists(bundleDirectory)}");
+            Assert.IsTrue(Directory.Exists(bundleDirectory));
+            Assert.IsTrue(File.Exists(bundlePackageContentsPath));
+
+            Thread.Sleep(1000);
+
+            var fileName = "File.xml";
+            var files = Directory.GetFiles(bundleDirectory, fileName, SearchOption.AllDirectories);
+            Assert.IsTrue(files.Length > 0, $"File '{fileName}' not found in bundle directory.");
+            var streams = files.Select(file => File.Open(file, FileMode.Open, FileAccess.Read, FileShare.None)).ToArray();
+
+            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName);
+            Console.WriteLine($"Bundle Exists: {Directory.Exists(bundleDirectory)}");
+
+            Assert.IsTrue(Directory.Exists(bundleDirectory));
+            Assert.IsFalse(File.Exists(bundlePackageContentsPath));
+
+            foreach (var stream in streams)
+            {
+                stream.Dispose();
+            }
+
+            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName);
+            Console.WriteLine($"Bundle Exists: {Directory.Exists(bundleDirectory)}");
+
+            Assert.IsFalse(Directory.Exists(bundleDirectory));
         }
     }
 }

--- a/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
@@ -61,6 +61,8 @@ namespace ricaun.Revit.Installation.Tests
         {
             var bundleUrl = $@"https://github.com/ricaun-io/{projectName}/releases/latest/download/{projectName}.bundle.zip";
 
+            //applicationPluginsFolder = RevitUtils.GetCurrentUserApplicationPluginsFolder();
+
             var bundleName = Path.GetFileNameWithoutExtension(bundleUrl);
 
             Console.WriteLine($"DownloadBundle: {bundleName}");
@@ -69,17 +71,15 @@ namespace ricaun.Revit.Installation.Tests
             {
                 Console.WriteLine(e);
                 Assert.Fail(e.Message);
-            }, (log) =>
-            {
-                Console.WriteLine(log);
             });
+            //}, Log);
 
             Console.WriteLine($"Bundle Exists: {Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName))}");
             Assert.IsTrue(Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName)));
 
             Thread.Sleep(1000);
 
-            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName);
+            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName, Log);
             Console.WriteLine($"Bundle Exists: {Directory.Exists(Path.Combine(applicationPluginsFolder, bundleName))}");
         }
 

--- a/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
+++ b/ricaun.Revit.Installation.Tests/ApplicationPluginsUtils_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using NUnit.Framework.Constraints;
+using NUnit.Framework.Internal;
 using ricaun.Revit.Installation.Tests.Utils;
 using System;
 using System.Collections.Generic;
@@ -120,8 +121,10 @@ namespace ricaun.Revit.Installation.Tests
             Assert.IsFalse(Directory.Exists(bundleDirectory));
         }
 
-        [TestCase("FakeBundleUsedByProcess")]
-        public void ApplicationPluginsUtils_Test_BundleCreatorUtils_FileUsedByProcess(string projectName)
+        [TestCase("FakeBundleUsedByProcess", 0)]
+        [TestCase("FakeBundleUsedByProcess", 1)]
+        [TestCase("FakeBundleUsedByProcess", 2)]
+        public void ApplicationPluginsUtils_Test_BundleCreatorUtils_FileUsedByProcess(string projectName, int numberFile)
         {
             projectName += Guid.NewGuid().ToString("N");
             var bundleUrl = BundleCreatorUtils.CreateBundleZip(projectName);
@@ -135,10 +138,7 @@ namespace ricaun.Revit.Installation.Tests
             {
                 Console.WriteLine(e);
                 Assert.Fail(e.Message);
-            }, (log) =>
-            {
-                Console.WriteLine(log);
-            });
+            }, Log);
 
             var bundleDirectory = Path.Combine(applicationPluginsFolder, bundleName);
             var bundlePackageContentsPath = Path.Combine(bundleDirectory, "PackageContents.xml");
@@ -150,25 +150,37 @@ namespace ricaun.Revit.Installation.Tests
             Thread.Sleep(1000);
 
             var fileName = "File.xml";
-            var files = Directory.GetFiles(bundleDirectory, fileName, SearchOption.AllDirectories);
-            Assert.IsTrue(files.Length > 0, $"File '{fileName}' not found in bundle directory.");
+            var fileNumberName = $"Number_{numberFile}.xml";
+            var files = Directory.GetFiles(bundleDirectory, fileNumberName, SearchOption.AllDirectories);
+            Assert.IsTrue(files.Length > 0, $"File '{fileNumberName}' not found in bundle directory.");
             var streams = files.Select(file => File.Open(file, FileMode.Open, FileAccess.Read, FileShare.None)).ToArray();
-
-            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName);
+            var filesCount = files.Select(file => Directory.GetFiles(Path.GetDirectoryName(file), "*").Length).Sum();
+            
+            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName, Log);
             Console.WriteLine($"Bundle Exists: {Directory.Exists(bundleDirectory)}");
 
             Assert.IsTrue(Directory.Exists(bundleDirectory));
             Assert.IsFalse(File.Exists(bundlePackageContentsPath));
+
+            var filesCountAfter = files.Select(file => Directory.GetFiles(Path.GetDirectoryName(file), "*").Length).Sum();
+            Assert.AreEqual(filesCount, filesCountAfter, "Files were deleted while they were still in use.");
+            foreach (var file in files)
+            {
+                var fileNamePath = Path.Combine(Path.GetDirectoryName(file), fileName);
+                Assert.IsTrue(File.Exists(fileNamePath), "File was deleted while is not been used, but some file and the same folder is been used.");
+            }
 
             foreach (var stream in streams)
             {
                 stream.Dispose();
             }
 
-            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName);
+            ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, bundleName, Log);
             Console.WriteLine($"Bundle Exists: {Directory.Exists(bundleDirectory)}");
 
             Assert.IsFalse(Directory.Exists(bundleDirectory));
         }
+
+        private static void Log(string message) => Console.WriteLine(message);
     }
 }

--- a/ricaun.Revit.Installation.Tests/Utils/BundleCreatorUtils.cs
+++ b/ricaun.Revit.Installation.Tests/Utils/BundleCreatorUtils.cs
@@ -6,7 +6,7 @@ namespace ricaun.Revit.Installation.Tests.Utils
 {
     public static class BundleCreatorUtils
     {
-        public static string CreateBundleZip(string projectName, bool includeBundleDirectory = true, bool includeContents = true)
+        public static string CreateBundleZip(string projectName, bool includeBundleDirectory = true, bool includeContents = true, int numberFileMax = 5)
         {
             var bundleFileName = $"{projectName}.bundle";
             var zipFileName = $"{bundleFileName}.zip";
@@ -28,8 +28,15 @@ namespace ricaun.Revit.Installation.Tests.Utils
             {
                 var contentsFolder = Path.Combine(sourceBundlePath, "Contents");
                 Directory.CreateDirectory(contentsFolder);
-                var contentFile = Path.Combine(contentsFolder, "File.xml");
-                File.WriteAllText(contentFile, string.Empty);
+                for (int i = 0; i < numberFileMax; i++)
+                {
+                    var numberFolder = Path.Combine(contentsFolder, $"Number_{i}");
+                    Directory.CreateDirectory(numberFolder);
+                    var contentFile = Path.Combine(numberFolder, "File.xml");
+                    File.WriteAllText(contentFile, string.Empty);
+                    var numberFile = Path.Combine(numberFolder, $"Number_{i}.xml");
+                    File.WriteAllText(numberFile, string.Empty);
+                }
             }
 
             ZipFile.CreateFromDirectory(sourceBundlePath, zipFilePath, CompressionLevel.NoCompression, includeBundleDirectory);

--- a/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
+++ b/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
@@ -235,9 +235,9 @@ namespace ricaun.Revit.Installation
                     var completeFileName = Path.Combine(destinationDirectoryName, fileFullName);
                     var directory = Path.GetDirectoryName(completeFileName);
 
-                    Debug.WriteLine($"{fileFullName} |\t {baseDirectory} |\t {completeFileName}");
+                    Debug.WriteLine($"{fileFullName} -\t {baseDirectory} -\t {completeFileName}");
 
-                    logFileConsole?.Invoke($"{fileFullName} |\t {baseDirectory} |\t {completeFileName}");
+                    logFileConsole?.Invoke($"{fileFullName} -\t {baseDirectory} -\t {completeFileName}");
 
                     if (!Directory.Exists(directory) && !string.IsNullOrEmpty(directory))
                         Directory.CreateDirectory(directory);

--- a/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
+++ b/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
@@ -26,8 +26,9 @@ namespace ricaun.Revit.Installation
         /// </summary>
         /// <param name="applicationPluginsFolder"></param>
         /// <param name="bundleName"></param>
+        /// <param name="logFileConsole"></param>
         /// <exception cref="Exception"></exception>
-        public static void DeleteBundle(string applicationPluginsFolder, string bundleName)
+        public static void DeleteBundle(string applicationPluginsFolder, string bundleName, Action<string> logFileConsole = null)
         {
             if (bundleName.EndsWith(CONST_BUNDLE) == false)
                 throw new Exception(string.Format("BundleName {0} does not end with {0}", bundleName, CONST_BUNDLE));
@@ -44,13 +45,14 @@ namespace ricaun.Revit.Installation
             void DeletePackageContents(string directory)
             {
                 if (!Directory.Exists(directory)) return;
-                foreach (var file in Directory.GetFiles(directory, CONST_PACKAGE_CONTENTS))
+                foreach (var file in Directory.GetFiles(directory, CONST_PACKAGE_CONTENTS, SearchOption.AllDirectories))
                 {
                     try
                     {
                         File.Delete(file);
+                        logFileConsole?.Invoke($"Deleted File: {file}");
                     }
-                    catch { }
+                    catch { logFileConsole?.Invoke($"Not Deleted File: {file}"); }
                 }
             }
 
@@ -60,18 +62,15 @@ namespace ricaun.Revit.Installation
                 if (!dir.Exists) return;
                 try
                 {
+                    var originalDirName = dir.FullName;
+                    dir.MoveTo(dir.FullName + "_Deleted_" + Guid.NewGuid().ToString("N"));
                     dir.Delete(true);
+                    logFileConsole?.Invoke($"Deleted Directory: {originalDirName}");
                     return;
                 }
-                catch { }
+                catch { logFileConsole?.Invoke($"Not Deleted Directory: {dir.FullName}"); }
                 foreach (DirectoryInfo di in dir.GetDirectories())
                 {
-                    try
-                    {
-                        di.Delete(true);
-                        continue;
-                    }
-                    catch { }
                     DeleteDirectories(di.FullName);
                 }
             }

--- a/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
+++ b/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
@@ -9,25 +9,49 @@ using System.Threading;
 namespace ricaun.Revit.Installation
 {
     /// <summary>
-    /// ApplicationPluginsUtils
-    /// <code>Based: https://github.com/ricaun-io/ricaun.Revit.Github/blob/master/ricaun.Revit.Github/Services/DownloadBundleService.cs</code>
+    /// Utility helpers to manage Revit application plugins bundles.
     /// </summary>
+    /// <remarks>
+    /// Provides functionality to delete bundles from an ApplicationPlugins folder,
+    /// download bundle ZIP files from an address and extract them, and several
+    /// internal helpers related to ZIP extraction and path handling.
+    /// Based on: https://github.com/ricaun-io/ricaun.Revit.Github/blob/master/ricaun.Revit.Github/Services/DownloadBundleService.cs
+    /// </remarks>
     public class ApplicationPluginsUtils
     {
         #region const
+        /// <summary>
+        /// File-system suffix used to identify Revit bundle folders.
+        /// </summary>
         private const string CONST_BUNDLE = ".bundle";
+
+        /// <summary>
+        /// Timeout (in milliseconds) used when waiting for a named <see cref="Mutex"/>.
+        /// </summary>
         private const int MutexMillisecondsTimeout = 10000;
+
+        /// <summary>
+        /// File name used to identify the bundle manifest file inside a bundle.
+        /// </summary>
         private const string CONST_PACKAGE_CONTENTS = "PackageContents.xml";
         #endregion
 
         #region Delete
         /// <summary>
-        /// DeleteBundle
+        /// Deletes a bundle folder and removes its bundle manifest files.
         /// </summary>
-        /// <param name="applicationPluginsFolder"></param>
-        /// <param name="bundleName"></param>
-        /// <param name="logFileConsole"></param>
-        /// <exception cref="Exception"></exception>
+        /// <param name="applicationPluginsFolder">
+        /// The root folder that contains application plugin bundles or the full path to a single `.bundle` folder.
+        /// </param>
+        /// <param name="bundleName">
+        /// The name of the bundle directory to delete. Must end with <c>".bundle"</c>.
+        /// </param>
+        /// <param name="logFileConsole">
+        /// Optional callback invoked with human-readable log messages for file and directory operations.
+        /// </param>
+        /// <exception cref="Exception">
+        /// Thrown if <paramref name="bundleName"/> does not end with the expected <c>".bundle"</c> suffix.
+        /// </exception>
         public static void DeleteBundle(string applicationPluginsFolder, string bundleName, Action<string> logFileConsole = null)
         {
             if (bundleName.EndsWith(CONST_BUNDLE) == false)
@@ -79,13 +103,38 @@ namespace ricaun.Revit.Installation
 
         #region Download
         /// <summary>
-        /// Download and unzip Bundle
+        /// Downloads a bundle ZIP from the specified <paramref name="address"/> and extracts it into the
+        /// provided <paramref name="applicationPluginsFolder"/> (or into a subfolder named after the bundle).
         /// </summary>
-        /// <param name="applicationPluginsFolder">Folder of the ApplicationPlugins or the Application.bundle</param>
-        /// <param name="address"></param>
-        /// <param name="downloadFileException"></param>
-        /// <param name="logFileConsole"></param>
-        /// <returns></returns>
+        /// <param name="applicationPluginsFolder">
+        /// The destination folder that contains ApplicationPlugins bundles or the full path to a single
+        /// `.bundle` folder. If the folder does not exist it will be created.
+        /// </param>
+        /// <param name="address">
+        /// The source address (typically an HTTP(S) URL) of the bundle ZIP file to download. The file name
+        /// portion of the address is used to create a temporary ZIP file inside <paramref name="applicationPluginsFolder"/>.
+        /// </param>
+        /// <param name="downloadFileException">
+        /// Optional callback invoked when an exception occurs during download or extraction. The exception
+        /// instance is provided to the callback for logging or handling. If this callback is null, exceptions
+        /// are caught silently and the method will return <c>false</c>.
+        /// </param>
+        /// <param name="logFileConsole">
+        /// Optional callback invoked with human-readable log messages for file and directory operations
+        /// performed during download and extraction.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the bundle was successfully downloaded and extraction was attempted; otherwise <c>false</c>.
+        /// Note: extraction may be a no-op if the downloaded file is not a ZIP; the method still returns <c>true</c> when
+        /// no exceptions were raised during the operation.
+        /// </returns>
+        /// <remarks>
+        /// - A named <see cref="Mutex"/> based on the bundle name (derived from the ZIP file name) is used to
+        ///   avoid concurrent operations on the same bundle.
+        /// - TLS 1.2 is enabled via <see cref="System.Net.ServicePointManager"/> to ensure secure downloads.
+        /// - The temporary ZIP file is deleted after extraction attempt regardless of success or failure.
+        /// - Any exceptions that occur are forwarded to <paramref name="downloadFileException"/> if provided.
+        /// </remarks>
         public static bool DownloadBundle(string applicationPluginsFolder, string address, Action<Exception> downloadFileException = null, Action<string> logFileConsole = null)
         {
             if (!Directory.Exists(applicationPluginsFolder))

--- a/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
+++ b/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
@@ -74,9 +74,9 @@ namespace ricaun.Revit.Installation
                     try
                     {
                         File.Delete(file);
-                        logFileConsole?.Invoke($"Deleted File: {file}");
+                        logFileConsole?.Invoke($"Deleted File: '{file}'");
                     }
-                    catch { logFileConsole?.Invoke($"Not Deleted File: {file}"); }
+                    catch { logFileConsole?.Invoke($"Not Deleted File: '{file}'"); }
                 }
             }
 
@@ -84,19 +84,43 @@ namespace ricaun.Revit.Installation
             {
                 DirectoryInfo dir = new DirectoryInfo(directory);
                 if (!dir.Exists) return;
-                try
-                {
-                    var originalDirName = dir.FullName;
-                    dir.MoveTo(dir.FullName + "_Deleted_" + Guid.NewGuid().ToString("N"));
-                    dir.Delete(true);
-                    logFileConsole?.Invoke($"Deleted Directory: {originalDirName}");
-                    return;
-                }
-                catch { logFileConsole?.Invoke($"Not Deleted Directory: {dir.FullName}"); }
+
+                // Start deleting the subdirectories first to avoid checking the same files multiple times.
+                // And if the directory contains subdirectories, it will not be deleted until all the subdirectories are deleted.
                 foreach (DirectoryInfo di in dir.GetDirectories())
                 {
                     DeleteDirectories(di.FullName);
                 }
+
+                try
+                {
+                    if (Directory.GetDirectories(dir.FullName).Length > 0)
+                    {
+                        throw new IOException($"Directory '{dir.FullName}' contains subdirectories and cannot be deleted.");
+                    }
+                    if (HasAnyFileInUse(dir.FullName))
+                    {
+                        throw new IOException($"Directory '{dir.FullName}' contains files that are currently in use and cannot be deleted.");
+                    }
+                    dir.Delete(true);
+                    logFileConsole?.Invoke($"Deleted Directory: '{dir.FullName}'");
+                    return;
+                }
+                catch (Exception ex) { logFileConsole?.Invoke($"Not Deleted Directory: {ex.Message}"); }
+            }
+
+            bool HasAnyFileInUse(string directory)
+            {
+                if (!Directory.Exists(directory)) return false;
+                foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories))
+                {
+                    try
+                    {
+                        using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+                    }
+                    catch { return true; }
+                }
+                return false;
             }
         }
         #endregion

--- a/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
+++ b/ricaun.Revit.Installation/ApplicationPluginsUtils.cs
@@ -35,36 +35,45 @@ namespace ricaun.Revit.Installation
             using (var mutex = new Mutex(false, bundleName))
             {
                 mutex.WaitOne(MutexMillisecondsTimeout);
-                DeleteDirectoryAndFiles(Path.Combine(applicationPluginsFolder, bundleName));
+                var bundleDirectory = Path.Combine(applicationPluginsFolder, bundleName);
+                DeleteDirectories(bundleDirectory);
+                DeletePackageContents(bundleDirectory);
                 mutex.ReleaseMutex();
             }
 
-            void DeleteDirectoryAndFiles(string directory)
+            void DeletePackageContents(string directory)
+            {
+                if (!Directory.Exists(directory)) return;
+                foreach (var file in Directory.GetFiles(directory, CONST_PACKAGE_CONTENTS))
+                {
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch { }
+                }
+            }
+
+            void DeleteDirectories(string directory)
             {
                 DirectoryInfo dir = new DirectoryInfo(directory);
                 if (!dir.Exists) return;
-                foreach (FileInfo fi in dir.GetFiles())
-                {
-                    try
-                    {
-                        fi.Delete();
-                    }
-                    catch { }
-                }
-                foreach (DirectoryInfo di in dir.GetDirectories())
-                {
-                    DeleteDirectoryAndFiles(di.FullName);
-                    try
-                    {
-                        di.Delete();
-                    }
-                    catch { }
-                }
                 try
                 {
-                    dir.Delete();
+                    dir.Delete(true);
+                    return;
                 }
                 catch { }
+                foreach (DirectoryInfo di in dir.GetDirectories())
+                {
+                    try
+                    {
+                        di.Delete(true);
+                        continue;
+                    }
+                    catch { }
+                    DeleteDirectories(di.FullName);
+                }
             }
         }
         #endregion


### PR DESCRIPTION
### Updates
- Change how `DeleteBundle` deletes the bundle folder, try to move/delete each folder inside and delete `PackageContents.xml`.
- Update `DeleteDirectories` to check if folder contains any file been used by any process, if so the deletion will be skipped.
### Tests
- Update `ApplicationPluginsUtils_Tests` to check if the bundle folder is deleted.